### PR TITLE
Fix GitHub Pages artifact path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: dist
+          path: apps/web/dist
 
   deploy:
     environment:


### PR DESCRIPTION
## Summary
- update the GitHub Pages deployment workflow to upload the built site from apps/web/dist

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6917657017408327b0a1ab5268562e00)